### PR TITLE
The job class should exist

### DIFF
--- a/src/StripeWebhookCall.php
+++ b/src/StripeWebhookCall.php
@@ -18,7 +18,7 @@ class StripeWebhookCall extends Model
     {
         $jobClass = $this->determineJobClass($this->type);
 
-        if ($jobClass === '') {
+        if (! class_exists($jobClass) {
             return;
         }
 


### PR DESCRIPTION
Instead of checking if the job class isn't empty, it's better to check if it exists.