### PR TITLE
[bugfix] Add missing param to jobClassDoesNotExist method

### DIFF
--- a/src/StripeWebhookCall.php
+++ b/src/StripeWebhookCall.php
@@ -32,7 +32,7 @@ class StripeWebhookCall extends Model
         }
 
         if (! class_exists($jobClass)) {
-            throw WebhookFailed::jobClassDoesNotExist($this);
+            throw WebhookFailed::jobClassDoesNotExist($jobClass, $this);
         }
 
         dispatch(new $jobClass($this));


### PR DESCRIPTION
[See the method here](https://github.com/spatie/laravel-stripe-webhooks/blob/eb7845d068607081fba6a04ed2a9408872d7b1a3/src/Exceptions/WebhookFailed.php#L25). Not sure if something should be added to the changelog..