### PR TITLE
add support for stripe-php v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "illuminate/support": "~5.5.0|~5.6.0",
-        "stripe/stripe-php": "^5.2"
+        "stripe/stripe-php": "^5.2|^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0",


### PR DESCRIPTION
This PR adds support for latest `stripe-php` release.

No BC were found, except dropping PHP 5.3 which is not case at all for this package.