### PR TITLE
Corrected namespace on example webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you want to do something when a specific event type comes in you can define a
 ```php
 <?php
 
-namespace App\Jobs;
+namespace App\Jobs\StripeWebhooks;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;


### PR DESCRIPTION
The webhook example provided needs an additional namespace path to fit with the provided configuration file change.

I added the missing class path/directory name on the namespace of the webhook class rather than removing it from the config file, as it felt better to keep all the 'StripeWebhook' jobs together.