### PR TITLE
Updated documentation for multiple secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ When using [Stripe Connect](https://stripe.com/connect) you might want to the pa
 First add a route which includes the parameter `configKey`:
 
 ```php
-Route::post('webhook-url/{configKey}', 'Spatie\StripeWebhooks\StripeWebhooksController');
+Route::stripeWebhooks('webhook-url/{configKey}', 'Spatie\StripeWebhooks\StripeWebhooksController');
 ```
 
 If this route parameter is present the verify middleware will look for the secret using a different config key, by appending the given the parameter value to the default config key. E.g. If Stripe posts to `webhook-url/my-named-secret` you'd add a new config named `signing_secret_my-named-secret`.

--- a/README.md
+++ b/README.md
@@ -230,10 +230,16 @@ class MyCustomWebhookCall extends StripeWebhookCall
 
 When using [Stripe Connect](https://stripe.com/connect) you might want to the package to handle multiple endpoints and secrets. Here's how to configurate that behaviour.
 
-First add a route which includes the parameter `configKey`:
+If you are using the `Route::stripeWebhooks` macro, you can append the `configKey` as follows:
 
 ```php
-Route::stripeWebhooks('webhook-url/{configKey}', 'Spatie\StripeWebhooks\StripeWebhooksController');
+Route::stripeWebhooks('webhook-url/{configKey}');
+```
+
+Alternatively, if you are manually defining the route, you can add `configKey` like so:
+
+```php
+Route::post('webhook-url/{configKey}', 'Spatie\StripeWebhooks\StripeWebhooksController');
 ```
 
 If this route parameter is present the verify middleware will look for the secret using a different config key, by appending the given the parameter value to the default config key. E.g. If Stripe posts to `webhook-url/my-named-secret` you'd add a new config named `signing_secret_my-named-secret`.


### PR DESCRIPTION
Documentation previously mentioned using only `:post` when defining Stripe connect routes.  Clarified this for consistency.