### PR TITLE
Response back json message

### DIFF
--- a/src/StripeWebhooksController.php
+++ b/src/StripeWebhooksController.php
@@ -32,5 +32,7 @@ class StripeWebhooksController extends Controller
 
             throw $exception;
         }
+
+        return response()->json(['message' => 'Webhook Handled']);
     }
 }


### PR DESCRIPTION
Hi, there

I noticed that the controller is not sending anything back. 

Packages like [laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) relies on response type to [inject](https://github.com/barryvdh/laravel-debugbar/blob/master/src/LaravelDebugbar.php#L618) their content along with response.
See the response in attached secreenshot. It contains the laravel debugbar styles and scripts.

There might be application level middleware that is trying to modify the response. Sending the response object back will help them to determine what type of content is being sent back.

See how Laravel Cashier is sending the response back
https://github.com/laravel/cashier/blob/be0bbad876b7510e39a7d29bc6ce9cff7a3979e4/src/Http/Controllers/WebhookController.php#L85

I know that  no one is using debugbar in production, but also
there is no harm returning JSON response to stripe. This would be a non breaking change.

Thanks

![dashboard stripe com_test_webhooks_we_1drn4ob0wauomgrgfpp1gbeg](https://user-images.githubusercontent.com/6111524/47847526-81d6e080-ddf1-11e8-82d9-32fc314d56c3.png)
