### PR TITLE
Allow stripe-php 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2",
         "illuminate/support": "~5.8.0|^6.0",
         "spatie/laravel-webhook-client": "^2.0",
-        "stripe/stripe-php": "^5.2|^6.0"
+        "stripe/stripe-php": "^5.2|^6.0|^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.8.0|^4.0",


### PR DESCRIPTION
Hi @riasvdv

Stripe has releases `stripe-php` v7.0 recently but this package does not allow to install it.

https://github.com/stripe/stripe-php/wiki/Migration-guide-for-v7

I think it is safe to allow as i dont see any changes related to Webhook.

Thanks.