### PR TITLE
Fixed controller path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Route::stripeWebhooks('webhook-url/{configKey}');
 Alternatively, if you are manually defining the route, you can add `configKey` like so:
 
 ```php
-Route::post('webhook-url/{configKey}', 'Spatie\StripeWebhooks\StripeWebhooksController');
+Route::post('webhook-url/{configKey}', '\Spatie\StripeWebhooks\StripeWebhooksController');
 ```
 
 If this route parameter is present the verify middleware will look for the secret using a different config key, by appending the given the parameter value to the default config key. E.g. If Stripe posts to `webhook-url/my-named-secret` you'd add a new config named `signing_secret_my-named-secret`.


### PR DESCRIPTION
With out the leading `\` the following exception will get thrown:
> UnexpectedValueException
> Invalid route action: [App\Http\Controllers\Spatie\StripeWebhooks\StripeWebhooksController]