### PR TITLE
Option for enable or disable signature verification

### DIFF
--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -1,8 +1,6 @@
 <?php
 
 return [
-    'verify_signature' => env('STRIPE_SIGNATURE_VERIFY', true),
-
     /*
      * Stripe will sign each webhook using a secret. You can find the used secret at the
      * webhook configuration settings: https://dashboard.stripe.com/account/webhooks.
@@ -26,4 +24,10 @@ return [
      * Spatie\StripeWebhooks\ProcessStripeWebhookJob.
      */
     'model' => \Spatie\StripeWebhooks\ProcessStripeWebhookJob::class,
+    
+    /*
+     * When disabled, the package will not verify if the signature is valid.
+     * This can be handy in local environments.
+     */
+    'verify_signature' => env('STRIPE_SIGNATURE_VERIFY', true),
 ];

--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'verify_signature' => env('STRIPE_SIGNATURE_VERIFY', true),
 
     /*
      * Stripe will sign each webhook using a secret. You can find the used secret at the

--- a/src/StripeSignatureValidator.php
+++ b/src/StripeSignatureValidator.php
@@ -12,6 +12,10 @@ class StripeSignatureValidator implements SignatureValidator
 {
     public function isValid(Request $request, WebhookConfig $config): bool
     {
+        if(!config('stripe-webhooks.verify_signature')){
+            return true;
+        }
+        
         $signature = $request->header('Stripe-Signature');
         $secret = $config->signingSecret;
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -56,6 +56,81 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function a_request_with_invalid_signature_with_verification_disabled()
+    {
+        config(['stripe-webhooks.verify_signature' => false]);
+        cache()->clear();
+
+        $this->withoutExceptionHandling();
+
+        $payload = [
+            'type' => 'my.type',
+            'key' => 'value',
+        ];
+
+        $headers = ['Stripe-Signature' => 'invalid signature'];
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this->assertCount(1, WebhookCall::get());
+
+        $webhookCall = WebhookCall::first();
+
+        $this->assertEquals('my.type', $webhookCall->payload['type']);
+        $this->assertEquals($payload, $webhookCall->payload);
+        $this->assertNull($webhookCall->exception);
+
+        Event::assertDispatched('stripe-webhooks::my.type', function ($event, $eventPayload) use ($webhookCall) {
+            $this->assertInstanceOf(WebhookCall::class, $eventPayload);
+            $this->assertEquals($webhookCall->id, $eventPayload->id);
+
+            return true;
+        });
+
+        $this->assertEquals($webhookCall->id, cache('dummyjob')->id);
+    }
+
+    /** @test */
+    public function a_request_without_signature_with_verification_disabled()
+    {
+        // had to explicit disable signature verification
+        config(['stripe-webhooks.verify_signature' => false]);
+        cache()->clear();
+
+        $this->withoutExceptionHandling();
+
+        $payload = [
+            'type' => 'my.type',
+            'key' => 'value',
+        ];
+
+        $headers = [];
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this->assertCount(1, WebhookCall::get());
+
+        $webhookCall = WebhookCall::first();
+
+        $this->assertEquals('my.type', $webhookCall->payload['type']);
+        $this->assertEquals($payload, $webhookCall->payload);
+        $this->assertNull($webhookCall->exception);
+
+        Event::assertDispatched('stripe-webhooks::my.type', function ($event, $eventPayload) use ($webhookCall) {
+            $this->assertInstanceOf(WebhookCall::class, $eventPayload);
+            $this->assertEquals($webhookCall->id, $eventPayload->id);
+
+            return true;
+        });
+
+        $this->assertEquals($webhookCall->id, cache('dummyjob')->id);
+    }
+
+    /** @test */
     public function a_request_with_an_invalid_signature_wont_be_logged()
     {
         $payload = [

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -56,7 +56,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function a_request_with_invalid_signature_with_verification_disabled()
+    public function a_request_with_invalid_signature_with_verification_disabled_will_pass()
     {
         config(['stripe-webhooks.verify_signature' => false]);
         cache()->clear();


### PR DESCRIPTION
It's for debugging purpose

It's awesome, safe me lot of work, 
i notice i need this when i want to simulate a webhook call from a rest client