### PR TITLE
Only process events once

### DIFF
--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -24,7 +24,12 @@ return [
      * Spatie\StripeWebhooks\ProcessStripeWebhookJob.
      */
     'model' => \Spatie\StripeWebhooks\ProcessStripeWebhookJob::class,
-    
+
+    /**
+     * This class determines if the webhook call should be stored and processed.
+     */
+    'profile' => \Spatie\StripeWebhooks\StripeWebhookProfile::class,
+
     /*
      * When disabled, the package will not verify if the signature is valid.
      * This can be handy in local environments.

--- a/src/StripeWebhookProfile.php
+++ b/src/StripeWebhookProfile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\StripeWebhooks;
+
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\Models\WebhookCall;
+use Spatie\WebhookClient\WebhookProfile\WebhookProfile;
+
+class StripeWebhookProfile implements WebhookProfile
+{
+    public function shouldProcess(Request $request): bool
+    {
+        return ! WebhookCall::whereJsonContains('payload->id', $request->get('id'))->exists();
+    }
+}

--- a/src/StripeWebhookProfile.php
+++ b/src/StripeWebhookProfile.php
@@ -10,6 +10,6 @@ class StripeWebhookProfile implements WebhookProfile
 {
     public function shouldProcess(Request $request): bool
     {
-        return ! WebhookCall::whereJsonContains('payload->id', $request->get('id'))->exists();
+        return ! WebhookCall::where('payload->id', $request->get('id'))->exists();
     }
 }

--- a/src/StripeWebhooksController.php
+++ b/src/StripeWebhooksController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Spatie\WebhookClient\Models\WebhookCall;
 use Spatie\WebhookClient\WebhookConfig;
 use Spatie\WebhookClient\WebhookProcessor;
-use Spatie\WebhookClient\WebhookProfile\ProcessEverythingWebhookProfile;
 
 class StripeWebhooksController
 {
@@ -19,7 +18,7 @@ class StripeWebhooksController
                 config('stripe-webhooks.signing_secret'),
             'signature_header_name' => 'Stripe-Signature',
             'signature_validator' => StripeSignatureValidator::class,
-            'webhook_profile' => ProcessEverythingWebhookProfile::class,
+            'webhook_profile' => StripeWebhookProfile::class,
             'webhook_model' => WebhookCall::class,
             'process_webhook_job' => config('stripe-webhooks.model'),
         ]);

--- a/src/StripeWebhooksController.php
+++ b/src/StripeWebhooksController.php
@@ -18,7 +18,7 @@ class StripeWebhooksController
                 config('stripe-webhooks.signing_secret'),
             'signature_header_name' => 'Stripe-Signature',
             'signature_validator' => StripeSignatureValidator::class,
-            'webhook_profile' => StripeWebhookProfile::class,
+            'webhook_profile' => config('stripe-webhooks.profile'),
             'webhook_model' => WebhookCall::class,
             'process_webhook_job' => config('stripe-webhooks.model'),
         ]);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -193,4 +193,25 @@ class IntegrationTest extends TestCase
             ->postJson('stripe-webhooks/somekey', $payload, $headers)
             ->assertSuccessful();
     }
+
+    /** @test */
+    public function a_request_will_only_be_processed_once()
+    {
+        $payload = [
+            'type' => 'my.type',
+            'key' => 'value',
+        ];
+
+        $headers = ['Stripe-Signature' => $this->determineStripeSignature($payload)];
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this->assertCount(1, WebhookCall::get());
+    }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -199,7 +199,7 @@ class IntegrationTest extends TestCase
     {
         $payload = [
             'type' => 'my.type',
-            'key' => 'value',
+            'id' => 'evt_123',
         ];
 
         $headers = ['Stripe-Signature' => $this->determineStripeSignature($payload)];
@@ -212,6 +212,6 @@ class IntegrationTest extends TestCase
             ->postJson('stripe-webhooks', $payload, $headers)
             ->assertSuccessful();
 
-        $this->assertCount(1, WebhookCall::get());
+        $this->assertCount(1, WebhookCall::where('payload->id', $payload['id'])->get());
     }
 }


### PR DESCRIPTION
This PR implements issue https://github.com/spatie/laravel-stripe-webhooks/issues/86.

I've added a new default `StripeWebhookProfile` class that determines if a webhook event was already processed before. If it was, the event will not be processed again.

You can also override that class in the config. This can be useful if you want to do add some additional logic to determine if an event should be processed or not.