### PR TITLE
Fix routing

### DIFF
--- a/src/StripeWebhooksServiceProvider.php
+++ b/src/StripeWebhooksServiceProvider.php
@@ -15,7 +15,7 @@ class StripeWebhooksServiceProvider extends PackageServiceProvider
             ->hasConfigFile();
 
         Route::macro('stripeWebhooks', function ($url) {
-            return Route::post($url, StripeWebhooksController::class);
+            return Route::post($url, '\Spatie\StripeWebhooks\StripeWebhooksController');
         });
     }
 }


### PR DESCRIPTION
Hi,

v3.0 introduce a breaking change that is not backward campatible.

When there is namespace specified in Laravel skeleton, the routing does not work.

Steps to reproduce
```php
<?php

namespace App\Providers;

use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
use Illuminate\Http\Request;
use Illuminate\Support\Facades\Route;

class RouteServiceProvider extends ServiceProvider
{
          // prefix the route in good old way
         protected $namespace = 'App\\Http\\Controllers';
}
```
Now define the route like this, by using macro
```php
// routes/web.php
<?php

// Stripe Webhooks
Route::group(['prefix' => 'webhooks/stripe', 'as' => 'webhooks.stripe.'], function () {
    Route::stripeWebhooks('/')->name('main');
});
```


This PR restores the routing back to as it used to be in v2.x