### PR TITLE
Add Unreleased Heading to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `laravel-stripe-webhooks` will be documented in this file
 
-## [Unreleased](https://github.com/spatie/laravel-stripe-webhooks/compare/3.1.0...HEAD)
+## [Unreleased](https://github.com/spatie/laravel-stripe-webhooks/compare/3.0.1...HEAD)
 
 ## 3.0.0 - 2021-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `laravel-stripe-webhooks` will be documented in this file
 
+## [Unreleased](https://github.com/spatie/laravel-stripe-webhooks/compare/3.1.0...HEAD)
+
 ## 3.0.0 - 2021-10-25
 
 - use spatie/laravel-webhook-client v3


### PR DESCRIPTION
This PRs adds an unreleased heading to the Changelog so that the [`changelog-updater-action`](https://github.com/spatie/laravel-stripe-webhooks/commit/50aacf59ef884848b117b8f1ab8f36196ef590bd) works as expected. (The Action needs that heading to know, where to place the relases notes)

See our Twitter discusssion: https://twitter.com/freekmurze/status/1456587699184340995

(The compare URL already uses the latest version 3.1.0 so that it would work correctly on the next release. You should update that URL to use 3.0.0 if you want to retry the Action somehow)