### PR TITLE
docs: fix upgrade guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,7 +38,7 @@ class AddColumnsToWebhookCalls extends Migration
     public function up(): void
     {
         Schema::table('webhook_calls', function (Blueprint $table) {
-            $table->string('url');
+            $table->string('url')->nullable();
             $table->json('headers')->nullable();
         });
     }


### PR DESCRIPTION
New columns must be nullable, since the table may have existing records