### PR TITLE
feat: process webhook once

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ return [
     /**
      * This class determines if the webhook call should be stored and processed.
      */
-    'profile' => \Spatie\WebhookClient\WebhookProfile\ProcessEverythingWebhookProfile::class,
+    'profile' => \Spatie\StripeWebhooks\StripeWebhookProfile::class,
 
     /*
      * When disabled, the package will not verify if the signature is valid.
@@ -112,7 +112,9 @@ Stripe will send out webhooks for several event types. You can find the [full li
 
 Stripe will sign all requests hitting the webhook url of your app. This package will automatically verify if the signature is valid. If it is not, the request was probably not sent by Stripe.
 
-Unless something goes terribly wrong, this package will always respond with a `200` to webhook requests. Sending a `200` will prevent Stripe from resending the same event over and over again. All webhook requests with a valid signature will be logged in the `webhook_calls` table. The table has a `payload` column where the entire payload of the incoming webhook is saved.
+Unless something goes terribly wrong, this package will always respond with a `200` to webhook requests. Sending a `200` will prevent Stripe from resending the same event over and over again.
+Stripe might occasionally send a duplicate webhook request [more than once](https://stripe.com/docs/webhooks/best-practices#duplicate-events). This package makes sure that each request will only be processed once.
+All webhook requests with a valid signature will be logged in the `webhook_calls` table. The table has a `payload` column where the entire payload of the incoming webhook is saved.
 
 If the signature is not valid, the request will not be logged in the `webhook_calls` table but a `Spatie\StripeWebhooks\WebhookFailed` exception will be thrown.
 If something goes wrong during the webhook request the thrown exception will be saved in the `exception` column. In that case the controller will send a `500` instead of `200`.
@@ -251,7 +253,7 @@ class MyCustomStripeWebhookJob extends ProcessStripeWebhookJob
 
 You may use your own logic to determine if a request should be processed or not. You can do this by specifying your own profile in the `profile` key of the `stripe-webhooks` config file. The class should implement `Spatie\WebhookClient\WebhookProfile\WebhookProfile`.
 
-Stripe might occasionally send a webhook request [more than once](https://stripe.com/docs/webhooks/best-practices#duplicate-events). In this example we will make sure to only process a request if it wasn't processed before.
+In this example we will make sure to only process a request if it wasn't processed before.
 
 ```php
 use Illuminate\Http\Request;

--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -28,7 +28,7 @@ return [
     /**
      * This class determines if the webhook call should be stored and processed.
      */
-    'profile' => \Spatie\WebhookClient\WebhookProfile\ProcessEverythingWebhookProfile::class,
+    'profile' => \Spatie\StripeWebhooks\StripeWebhookProfile::class,
 
     /*
      * When disabled, the package will not verify if the signature is valid.

--- a/src/StripeWebhookProfile.php
+++ b/src/StripeWebhookProfile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\StripeWebhooks;
+
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\Models\WebhookCall;
+use Spatie\WebhookClient\WebhookProfile\WebhookProfile;
+
+class StripeWebhookProfile implements WebhookProfile
+{
+    public function shouldProcess(Request $request): bool
+    {
+        return ! WebhookCall::where('payload->id', $request->get('id'))->exists();
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -193,4 +193,25 @@ class IntegrationTest extends TestCase
             ->postJson('stripe-webhooks/somekey', $payload, $headers)
             ->assertSuccessful();
     }
+
+    /** @test */
+    public function a_request_will_only_be_processed_once()
+    {
+        $payload = [
+            'type' => 'my.type',
+            'id' => 'evt_123',
+        ];
+
+        $headers = ['Stripe-Signature' => $this->determineStripeSignature($payload)];
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this
+            ->postJson('stripe-webhooks', $payload, $headers)
+            ->assertSuccessful();
+
+        $this->assertCount(1, WebhookCall::where('payload->id', $payload['id'])->get());
+    }
 }


### PR DESCRIPTION
Hi, @freekmurze 

Re-submission of PR https://github.com/spatie/laravel-stripe-webhooks/pull/87

Previous PR was [reverted](https://github.com/spatie/laravel-stripe-webhooks/pull/89) because the query `where("payload->id")` was not working on PostgreSQL.

The `payload` column was type of `text`, but in [newer](https://github.com/spatie/laravel-webhook-client/blob/main/database/migrations/create_webhook_calls_table.php.stub#L16) version it is `JSON` type

And now query is well supported by all databases
https://laravel.com/docs/8.x/queries#json-where-clauses

I did nothing special in this PR, imported changes from original PR. :)

cc @aerni
