### PR TITLE
fix: only check for stripe webhooks

### DIFF
--- a/src/StripeWebhookProfile.php
+++ b/src/StripeWebhookProfile.php
@@ -10,6 +10,6 @@ class StripeWebhookProfile implements WebhookProfile
 {
     public function shouldProcess(Request $request): bool
     {
-        return ! WebhookCall::where('payload->id', $request->get('id'))->exists();
+        return ! WebhookCall::where('name', 'stripe')->where('payload->id', $request->get('id'))->exists();
     }
 }


### PR DESCRIPTION
Hi,

There might be other type of webhooks being stored in `webhook_calls` table, for example mailcoach is storing `ses-feedback` webhooks.

This PR scope the SQL query to only search for `stripe` webhooks while checking for duplicates.

Thanks.