### PR TITLE
UPGRADING.md v3: Add payload column type change

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,7 @@ class AddColumnsToWebhookCalls extends Migration
         Schema::table('webhook_calls', function (Blueprint $table) {
             $table->string('url')->nullable();
             $table->json('headers')->nullable();
+            $table->json('payload')->change();
         });
     }
 
@@ -53,6 +54,7 @@ class AddColumnsToWebhookCalls extends Migration
         Schema::table('webhook_calls', function (Blueprint $table) {
             $table->dropColumn('url');
             $table->dropColumn('headers');
+            $table->text('payload')->change();
         });
     }
 }


### PR DESCRIPTION
For anyone upgrading from v2 to v3, this change is required because e.g. https://github.com/spatie/laravel-stripe-webhooks/blob/main/src/StripeWebhookProfile.php uses a json operator on the payload column.