### PR TITLE
let user able to define a default job as a catchall event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ return [
     'signing_secret' => env('STRIPE_WEBHOOK_SECRET'),
 
     /*
+     * You can define a default job that should be run for all other Stripe event type
+     * without a job defined in next configuration.
+     * You may leave it empty to store the job in database but without processing it.
+     */
+    'default_job' => '',
+
+    /*
      * You can define the job that should be run when a certain webhook hits your application
      * here. The key is the name of the Stripe event type with the `.` replaced by a `_`.
      *
@@ -169,6 +176,16 @@ After having created your job you must register it at the `jobs` array in the `s
 'jobs' => [
     'source_chargeable' => \App\Jobs\StripeWebhooks\HandleChargeableSource::class,
 ],
+```
+
+In case you want to configure one job as default to process all undefined event, you may set the job at `default_job` in
+the `stripe-webhooks.php` config file. The value should be the fully qualified classname.
+
+By default, the configuration is an empty string `''`, which will only store the event in database but without handling.
+
+```php
+// config/stripe-webhooks.php
+'default_job' => \App\Jobs\StripeWebhooks\HandleOtherEvent::class,
 ```
 
 ### Handling webhook requests using events

--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -8,6 +8,13 @@ return [
     'signing_secret' => env('STRIPE_WEBHOOK_SECRET'),
 
     /*
+     * You can define a default job that should be run for all other Stripe event type
+     * without a job defined in next configuration.
+     * You may leave it empty to store the job in database but without processing it.
+     */
+    'default_job' => '',
+
+    /*
      * You can define the job that should be run when a certain webhook hits your application
      * here. The key is the name of the Stripe event type with the `.` replaced by a `_`.
      *

--- a/src/ProcessStripeWebhookJob.php
+++ b/src/ProcessStripeWebhookJob.php
@@ -31,7 +31,9 @@ class ProcessStripeWebhookJob extends ProcessWebhookJob
     protected function determineJobClass(string $eventType): string
     {
         $jobConfigKey = str_replace('.', '_', $eventType);
+        
+        $defaultJob = config('stripe-webhooks.default_job', '');
 
-        return config("stripe-webhooks.jobs.{$jobConfigKey}", config('stripe-webhooks.default_job', ''));
+        return config("stripe-webhooks.jobs.{$jobConfigKey}", $defaultJob);
     }
 }

--- a/src/ProcessStripeWebhookJob.php
+++ b/src/ProcessStripeWebhookJob.php
@@ -32,6 +32,6 @@ class ProcessStripeWebhookJob extends ProcessWebhookJob
     {
         $jobConfigKey = str_replace('.', '_', $eventType);
 
-        return config("stripe-webhooks.jobs.{$jobConfigKey}", '');
+        return config("stripe-webhooks.jobs.{$jobConfigKey}", config('stripe-webhooks.default_job', ''));
     }
 }

--- a/tests/StripeWebhookCallTest.php
+++ b/tests/StripeWebhookCallTest.php
@@ -58,6 +58,19 @@ class StripeWebhookCallTest extends TestCase
     }
 
     /** @test */
+    public function it_will_dispatch_jobs_when_default_job_is_configured()
+    {
+        config([
+            'stripe-webhooks.jobs' => [],
+            'stripe-webhooks.default_job' => DummyJob::class
+        ]);
+
+        $this->processStripeWebhookJob->handle();
+
+        $this->assertEquals($this->webhookCall->id, cache('dummyjob')->id);
+    }
+
+    /** @test */
     public function it_will_dispatch_events_even_when_no_corresponding_job_is_configured()
     {
         config(['stripe-webhooks.jobs' => ['another_type' => DummyJob::class]]);


### PR DESCRIPTION
ref #127 

I didn't introduce a default job class within the package is because that might need involve adding a new laravel package for the queue, so using this simple approach first and let user do the customization.