### PR TITLE
allow stripe sdk v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.0",
         "illuminate/support": "^8.0|^9.0",
         "spatie/laravel-webhook-client": "^3.0",
-        "stripe/stripe-php": "^7.51|^8.0"
+        "stripe/stripe-php": "^7.51|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",


### PR DESCRIPTION
Hi,

v9 has been released recently, i dont see any breaking change regarding webhook except some constants which are not being used by this package.

https://github.com/stripe/stripe-php/blob/master/CHANGELOG.md#900---2022-08-02