### PR TITLE
feat: Add support for multiple signing secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `laravel-stripe-webhooks` will be documented in this file
 
 ## [Unreleased](https://github.com/spatie/laravel-stripe-webhooks/compare/3.10.3...HEAD)
+### What's Changed
+- Add support for multiple signing secrets
 
 ## [3.10.3](https://github.com/spatie/laravel-stripe-webhooks/compare/3.10.2...3.10.3) - 2025-04-04
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ This is the contents of the config file that will be published at `config/stripe
 
 ```php
 return [
-    /*
+   /*
      * Stripe will sign each webhook using a secret. You can find the used secret at the
      * webhook configuration settings: https://dashboard.stripe.com/account/webhooks.
+     *
+     * You can specify a single secret as a string, or multiple secrets as a comma-separated
+     * string in your .env file.
+     *
+     * E.g. STRIPE_WEBHOOK_SECRET="whsec_abc,whsec_xyz"
      */
-    'signing_secret' => env('STRIPE_WEBHOOK_SECRET'),
+    'signing_secret' => explode(',', env('STRIPE_WEBHOOK_SECRET')),
 
     /*
      * You can define a default job that should be run for all other Stripe event type
@@ -92,7 +97,17 @@ return [
 ];
 ```
 
-In the `signing_secret` key of the config file you should add a valid webhook secret. You can find the secret used at [the webhook configuration settings on the Stripe dashboard](https://dashboard.stripe.com/account/webhooks).
+In your .env file, add your webhook secret. You can find this in your Stripe dashboard in the webhook configuration settings. [the webhook configuration settings on the Stripe dashboard](https://dashboard.stripe.com/account/webhooks).
+
+```
+STRIPE_WEBHOOK_SECRET="whsec_..."
+```
+
+If you need to handle webhooks from multiple Stripe endpoints that each have their own secret (for example, when using both traditional "snapshot" payloads and newer "thin" payloads), you can add all secrets to your .env file as a comma-separated list. The package will automatically try each secret until it finds a match.
+
+```
+STRIPE_WEBHOOK_SECRET="whsec_snapshot_abc,whsec_thin_xyz"
+```
 
 Next, you must publish the migration with:
 ```bash

--- a/config/stripe-webhooks.php
+++ b/config/stripe-webhooks.php
@@ -2,10 +2,15 @@
 
 return [
     /*
-     * Stripe will sign each webhook using a secret. You can find the used secret at the
-     * webhook configuration settings: https://dashboard.stripe.com/account/webhooks.
-     */
-    'signing_secret' => env('STRIPE_WEBHOOK_SECRET'),
+      * Stripe will sign each webhook using a secret. You can find the used secret at the
+      * webhook configuration settings: https://dashboard.stripe.com/account/webhooks.
+      *
+      * You can specify a single secret as a string, or multiple secrets as a comma-separated
+      * string in your .env file.
+      *
+      * E.g. STRIPE_WEBHOOK_SECRET="whsec_abc,whsec_xyz"
+      */
+    'signing_secret' => explode(',', env('STRIPE_WEBHOOK_SECRET')),
 
     /*
      * You can define a default job that should be run for all other Stripe event type


### PR DESCRIPTION
This pull request adds support for verifying webhooks against multiple signing secrets.

#### The Problem

Stripe's newer products (e.g., Global Payouts) use 'thin' webhook payloads, which cannot be mixed with traditional 'snapshot' payloads in a single endpoint. This requires developers to configure two separate webhook endpoints, each with its own unique signing secret. The current package only supports a single `signing_secret`, making it impossible to validate events from both sources.

#### The Solution

This PR resolves the issue by allowing the `signing_secret` configuration to handle an array of secrets. The `StripeSignatureValidator` now iterates through each provided secret and accepts the webhook if a valid signature is found for any of them.

This change is fully backward-compatible for users who only provide a single secret.

#### Implementation Details

-   Modified `StripeSignatureValidator` to loop through an array of potential secrets.
-   Updated `config/stripe-webhooks.php` to use `explode()` for easy configuration of comma-separated secrets in the `.env` file.
-   Updated the `README.md` with usage instructions.
-   Updated `CHANGELOG.md`.